### PR TITLE
added --wait option

### DIFF
--- a/cli53.py
+++ b/cli53.py
@@ -230,7 +230,10 @@ def cmd_import(args):
     xml = f.create_all(zone, exclude=is_root_soa_or_ns)
 
     ret = r53.change_rrsets(args.zone, xml)
-    pprint(ret.ChangeResourceRecordSetsResponse)
+    if args.wait:
+        wait_for_sync(ret)
+    else:
+        pprint(ret.ChangeResourceRecordSetsResponse)
     
 re_zone_id = re.compile('^[A-Z0-9]{14}$')
 def Zone(zone):


### PR DESCRIPTION
I added a --wait flag that can be used with any action that modifies data.  If invoked, cli53.py will wait until the operation changes from PENDING to INSYNC.  This usually only takes about 5-10 seconds.

example:

```
$ ./cli53.py create testjoe2.com --wait
Waiting for change to sync......completed
ChangeInfo:
  Status: INSYNC
  SubmittedAt: 2010-12-17T02:26:00.928Z
  Id: /change/C25873BM5AHM6H
```

Inspired by this tool: https://github.com/pcorliss/ruby_route_53
