### PR TITLE
Include the cli53 package in the install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     version='0.1',
     description='Command line script to administer the Amazon Route 53 dns service.',
     package_dir={'': 'src'},
+    packages=['cli53'],
     install_requires=[
         'boto',
         'dnspython',


### PR DESCRIPTION
In pip, if the packages list is omitted, the packages are simply not put on the system
