### PR TITLE
Regex update to allow tab delimited $ORIGIN and $INCLUDE directives

### DIFF
--- a/src/cli53/cli53.py
+++ b/src/cli53/cli53.py
@@ -329,8 +329,8 @@ def cmd_xml(args):
     print 'This functionality is no longer available due to changes in the boto library.'
 
 re_dos = re.compile('\r\n$')
-re_origin = re.compile(r'\$ORIGIN (\S+)')
-re_include = re.compile(r'\$INCLUDE (\S+)')
+re_origin = re.compile(r'\$ORIGIN[ \t](\S+)')
+re_include = re.compile(r'\$INCLUDE[ \t](\S+)')
 def cmd_import(args):
     text = []
 


### PR DESCRIPTION
The existing regex matches for $ORIGIN and $INCLUDE directives expect space-delimited values.  This pull request allows tab-delimited values, which appears to be allowable by the original RFC [http://tools.ietf.org/html/rfc1035#section-5.1].

Without this change, purely tab-delimited zone files (such as those provided by Omnis) will fail to find the $ORIGIN directive due to the regex match.

P.S.  Thank you for such a useful tool!
