### PR TITLE
Diffing feature for import --replace

### DIFF
--- a/scripts/cli53
+++ b/scripts/cli53
@@ -225,10 +225,25 @@ class BindToR53Formatter(object):
         return li
 
     def create_all(self, zone, old_zone=None, exclude=None):
+        origin = zone.origin
+
         creates = self._build_list(zone, exclude)
         deletes = []
         if old_zone:
             deletes = self._build_list(old_zone, exclude)
+            
+        # remove duplicate entries from deletes and creates
+        common = []
+        for c in creates:
+            for c2 in deletes:
+                if c[0] == c2[0]:
+                    if c[1].to_text(origin=origin, relativize=False) == c2[1].to_text(origin=origin, relativize=False):
+                        common.append((c, c2))
+
+        for c in common:
+            creates.remove(c[0])
+            deletes.remove(c[1])
+                
         return self._xml_changes(zone, creates=creates, deletes=deletes)
 
     def delete_all(self, zone, exclude=None):


### PR DESCRIPTION
Hi,

I wanted to use cli53 to routinely push my zone file to Route 53, but it was hitting the 100 request limit each time I re-pushed it using the --replace tag. To combat that, I've modified "import --replace" to compare the zone you're sending with any records that are already on Route 53 and only delete/create an existing record if it's actually changed locally. Hopefully some other users will find this handy!

Thanks
Leigh
