### PR TITLE
Bug with definition of _xml_changes and default values

### DIFF
--- a/scripts/cli53
+++ b/scripts/cli53
@@ -290,7 +290,7 @@ class BindToR53Formatter(object):
     def replace_record(self, zone, name, rdataset_old, rdataset_new):
         return self._xml_changes(zone, creates=[(name,rdataset_new)], deletes=[(name,rdataset_old)])
 
-    def _xml_changes(self, zone, creates, deletes):
+    def _xml_changes(self, zone, creates=[], deletes=[]):
         for page in paginate(self._iter_changes(creates, deletes), 100):
             yield self._batch_change(zone, page)
 


### PR DESCRIPTION
Changed the definition of _xml_changes to include default values (empty lists) for creates and deletes so that the calls from delete_all/create_record/delete_record/etc which only provide either creates or deletes don't fail.

def _xml_changes(self, zone, creates, deletes):
