### PR TITLE
add required EvaluateTargetHealth element for Alias records

### DIFF
--- a/scripts/cli53
+++ b/scripts/cli53
@@ -382,6 +382,7 @@ class BindToR53Formatter(object):
                         text_element(at, 'HostedZoneId',
                             rdtype.alias_hosted_zone_id)
                         text_element(at, 'DNSName', rdtype.alias_dns_name)
+                        text_element(at, 'EvaluateTargetHealth', 'false')
                 elif rdataset.rdtype in (dns.rdatatype.A, dns.rdatatype.CNAME):
                     # Weighted A expands into multiple records (as each can
                     # have its own weighting/identifier)


### PR DESCRIPTION
zone file contains alias records when you use the S3 website feature:

```
$ORIGIN example.com.
@ 600 AWS ALIAS Z2F56UZL2M1ACD s3-website-us-west-1.amazonaws.com.
```

results in the following error on import:

```
cli53 import example.com --file example.com.txt 
Traceback (most recent call last):
  File "/usr/local/bin/cli53", line 966, in <module>
    main()
  File "/usr/local/bin/cli53", line 961, in main
    args.func(args)
  File "/usr/local/bin/cli53", line 599, in cmd_import
    ret = r53.change_rrsets(args.zone, xml)
  File "/usr/local/lib/python2.7/site-packages/boto/route53/connection.py", line 417, in change_rrsets
    body)
boto.route53.exception.DNSServerError: DNSServerError: 400 Bad Request
<?xml version="1.0"?>
<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><Error><Type>Sender</Type><Code>InvalidInput</Code><Message>Invalid XML ; cvc-complex-type.2.4.a: Invalid content was found starting with element 'EvaluateTargetHealth'. One of '{&quot;https://route53.amazonaws.com/doc/2013-04-01/&quot;:HostedZoneId}' is expected.</Message></Error><RequestId>1be26d95-ae1f-11e3-ad76-25e436c9fcb4</RequestId></ErrorResponse>
```
