### PR TITLE
Speed and accuracy improvements surrounding import --replace operations

### DIFF
--- a/scripts/cli53
+++ b/scripts/cli53
@@ -335,11 +335,19 @@ class BindToR53Formatter(object):
                 if c[0] == c2[0]:
                     if (sorted(c[1].to_text(origin=origin, relativize=False).split('\n')) ==
                         sorted(c2[1].to_text(origin=origin, relativize=False).split('\n')) ):
-                        common.append((c, c2))
+                        common.append(a)
 
-        for c in common:
-            creates.remove(c[0])
-            deletes.remove(c[1])
+	creates = []
+	deletes = []
+
+        for a in common:
+                        del createshash[a]
+                        del deleteshash[a]
+
+	for c in createshash:
+		creates.append(createshash[c])
+	for c in deleteshash:
+		deletes.append(deleteshash[c])
 
         return self._xml_changes(zone, creates=creates, deletes=deletes)
 


### PR DESCRIPTION
I picked up cli53 to handle syncing from a legacy system to AWS Route53.  

Attempts to sync my zone file, which the cut down minimal one is 22k RR's resulted in hilariously long run times (82 minutes of CPU), and needless replacement of some record types (MX records coming back in a different order than in the local zone file).

I'm not a python programmer.  I've hit this code with a hammer to make it run acceptably in my environment. 
Run time on my zone is down to 51 seconds wall clock, 18 seconds cpu.

Consider this, if not reasonable patches, at least suggestions on how to make it run faster.  Dig around in my branch history if you want the bits for the problems as isolated chunks.

Thanks.
