### PR TITLE
Support failover record types

### DIFF
--- a/scripts/cli53
+++ b/scripts/cli53
@@ -86,12 +86,13 @@ class AWS:
 
     class A(dns.rdtypes.IN.A.A):
         def __init__(self, rdclass, rdtype, address, weight,
-                     identifier, region):
+                     identifier, region, failover):
             super(dns.rdtypes.IN.A.A, self).__init__(rdclass, rdtype)
             self.address = address
             self.weight = weight
             self.identifier = identifier
             self.region = region
+            self.failover = failover
 
         def to_text(self, **kw):
             if kw.get('relativize'):
@@ -101,6 +102,9 @@ class AWS:
                 elif self.region is not None:
                     return 'region:%s %s %s' % (self.region, self.address,
                         self.identifier)
+                elif self.failover is not None:
+                    return 'failover:%s %s %s' % (self.failover, self.address,
+                        self.identifier)
             return self.address
 
         @classmethod
@@ -108,21 +112,25 @@ class AWS:
             fst = tok.get_string()
             weight = None
             region = None
+            failover = None
             if fst.startswith('region:'):
                 region = fst[7:]
+            elif fst.startswith('failover:'):
+                failover = fst[9:]
             else:
                 weight = fst
             address = tok.get_identifier()
             identifier = tok.get_string()
-            return cls(rdclass, rdtype, address, weight, identifier, region)
+            return cls(rdclass, rdtype, address, weight, identifier, region, failover)
 
     class CNAME(CustomBase):
         def __init__(self, rdclass, rdtype, target, weight,
-                     identifier, region):
+                     identifier, region, failover):
             super(CustomBase, self).__init__(rdclass, rdtype, target)
             self.weight = weight
             self.identifier = identifier
             self.region = region
+            self.failover = failover
 
         def to_text(self, **kw):
             if kw.get('relativize'):
@@ -132,6 +140,9 @@ class AWS:
                 elif self.region is not None:
                     return 'region:%s %s %s' % (self.region, self.target,
                         self.identifier)
+                elif self.failover is not None:
+                    return 'failover:%s %s %s' % (self.failover, self.target,
+                        self.identifier)
             return self.target
 
         @classmethod
@@ -139,23 +150,27 @@ class AWS:
             fst = tok.get_string()
             weight = None
             region = None
+            failover = None
             if fst.startswith('region:'):
                 region = fst[7:]
+            elif fst.startswith('failover:'):
+                failover = fst[9:]
             else:
                 weight = fst
             target = tok.get_string()
             identifier = tok.get_string()
-            return cls(rdclass, rdtype, target, weight, identifier, region)
+            return cls(rdclass, rdtype, target, weight, identifier, region, failover)
 
     class ALIAS(dns.rdata.Rdata):
         def __init__(self, rdclass, rdtype, hosted_zone_id, dns_name,
-                     weight, identifier, region):
+                     weight, identifier, region, failover):
             super(AWS.ALIAS, self).__init__(rdclass, rdtype)
             self.alias_hosted_zone_id = hosted_zone_id
             self.alias_dns_name = dns_name
             self.weight = weight
             self.identifier = identifier
             self.region = region
+            self.failover = failover
 
         def to_text(self, **kw):
             if kw.get('relativize'):
@@ -167,6 +182,10 @@ class AWS:
                     return 'region:%s %s %s %s' % (self.region,
                         self.alias_hosted_zone_id, self.alias_dns_name,
                         self.identifier)
+                elif self.failover is not None:
+                    return 'failover:%s %s %s' % (self.failover,
+                        self.alias_hosted_zone_id, self.alias_dns_name,
+                        self.identifier)
             return '%s %s' % (self.alias_hosted_zone_id, self.alias_dns_name)
 
         @classmethod
@@ -176,9 +195,12 @@ class AWS:
             weight = None
             region = None
             identifier = None
+            failover = None
             if fst.startswith('region:'):
                 region = fst[7:]
                 hosted_zone_id = tok.get_identifier()
+            elif fst.startswith('failover:'):
+                failover = fst[9:]
             elif re.match(weight_pattern, fst):
                 weight = int(fst)
                 hosted_zone_id = tok.get_identifier()
@@ -189,7 +211,7 @@ class AWS:
                 identifier = tok.get_string()
             tok.get_eol()
             return cls(rdclass, rdtype, hosted_zone_id, dns_name, weight,
-                identifier, region)
+                identifier, region, failover)
 
     RDTYPE_ALIAS = 65535
     dns.rdatatype._by_text['ALIAS'] = RDTYPE_ALIAS
@@ -453,7 +475,7 @@ class R53ToBindFormatter(object):
                     rrset.alias_dns_name)]
 
             rdataset = _create_rdataset(rtype, ttl, values, rrset.weight,
-                rrset.identifier, getattr(rrset, 'region', None))
+                rrset.identifier, getattr(rrset, 'region', None), getattr(rrset, 'failover', None))
             node = z.get_node(name, create=True)
             node.rdatasets.append(rdataset)
 
@@ -470,7 +492,7 @@ def unquote_list(v):
     return [re_backslash.sub('\\1', s) for s in re_quotepair.split(v[1:-1])]
 
 
-def _create_rdataset(rtype, ttl, values, weight, identifier, region):
+def _create_rdataset(rtype, ttl, values, weight, identifier, region, failover):
     rdataset = dns.rdataset.Rdataset(dns.rdataclass.IN,
         dns.rdatatype.from_text(rtype))
     rdataset.ttl = ttl
@@ -484,10 +506,13 @@ def _create_rdataset(rtype, ttl, values, weight, identifier, region):
                 rdataset.rdclass = AWS.RDCLASS
                 if weight is not None:
                     rdtype = AWS.A(AWS.RDCLASS, dns.rdatatype.A, value, weight,
-                        identifier, None)
+                        identifier, None, None)
                 elif region is not None:
                     rdtype = AWS.A(AWS.RDCLASS, dns.rdatatype.A, value, None,
-                        identifier, region)
+                        identifier, region, None)
+                elif failover is not None:
+                    rdtype = AWS.A(AWS.RDCLASS, dns.rdatatype.A, value, None,
+                        identifier, None, failover)
         elif rtype == 'AAAA':
             rdtype = AAAA(dns.rdataclass.IN, dns.rdatatype.AAAA, value)
         elif rtype == 'CNAME':
@@ -535,12 +560,14 @@ def _create_rdataset(rtype, ttl, values, weight, identifier, region):
             except ValueError:
                 raise ValueError('ALIAS records require two parts: hosted zone id and dns name of ELB')
             if identifier is None:
-                rdtype = AWS.ALIAS(AWS.RDCLASS, AWS.RDTYPE_ALIAS, hosted_zone_id, dns_name, None, identifier, None)
+                rdtype = AWS.ALIAS(AWS.RDCLASS, AWS.RDTYPE_ALIAS, hosted_zone_id, dns_name, None, identifier, None, None)
             else:
                 if weight is not None:
-                    rdtype = AWS.ALIAS(AWS.RDCLASS, AWS.RDTYPE_ALIAS, hosted_zone_id, dns_name, weight, identifier, None)
+                    rdtype = AWS.ALIAS(AWS.RDCLASS, AWS.RDTYPE_ALIAS, hosted_zone_id, dns_name, weight, identifier, None, None)
                 elif region is not None:
-                    rdtype = AWS.ALIAS(AWS.RDCLASS, AWS.RDTYPE_ALIAS, hosted_zone_id, dns_name, None, identifier, region)
+                    rdtype = AWS.ALIAS(AWS.RDCLASS, AWS.RDTYPE_ALIAS, hosted_zone_id, dns_name, None, identifier, region, None)
+                elif failover is not None:
+                    rdtype = AWS.ALIAS(AWS.RDCLASS, AWS.RDTYPE_ALIAS, hosted_zone_id, dns_name, None, identifier, None, failover)
 
         else:
             raise ValueError('record type %s not handled' % rtype)


### PR DESCRIPTION
boto added support for failover record types. Adding this to cli53 as well.
