### PR TITLE
Add the arguments to properly allow creation of failover record types

### DIFF
--- a/scripts/cli53
+++ b/scripts/cli53
@@ -207,7 +207,7 @@ class AWS:
             else:
                 hosted_zone_id = fst
             dns_name = tok.get_identifier()
-            if region or weight:
+            if region or weight or failover:
                 identifier = tok.get_string()
             tok.get_eol()
             return cls(rdclass, rdtype, hosted_zone_id, dns_name, weight,
@@ -402,6 +402,11 @@ class BindToR53Formatter(object):
                             text_element(rrset, 'SetIdentifier',
                                 rdtype.identifier)
                             text_element(rrset, 'Region', str(rdtype.region))
+                        elif rdtype.failover:
+                            text_element(rrset, 'SetIdentifier',
+                                rdtype.identifier)
+                            text_element(rrset, 'Failover',
+                                rdtype.failover)
                         at = et.SubElement(rrset, 'AliasTarget')
                         text_element(at, 'HostedZoneId',
                             rdtype.alias_hosted_zone_id)
@@ -419,6 +424,8 @@ class BindToR53Formatter(object):
                             text_element(rrset, 'Weight', str(rdtype.weight))
                         elif rdtype.region:
                             text_element(rrset, 'Region', str(rdtype.region))
+                        elif rdtype.failover:
+                            text_element(rrset, 'Failover', str(rdtype.failover))
                         text_element(rrset, 'TTL', str(rdataset.ttl))
                         rrs = et.SubElement(rrset, 'ResourceRecords')
                         rr = et.SubElement(rrs, 'ResourceRecord')
@@ -739,7 +746,7 @@ def cmd_instances(args):
                 logging.info('Creating record for %s: %s' % (name, newvalue))
 
             if newvalue:
-                rd = _create_rdataset('CNAME', args.ttl, [newvalue], None, None, None)
+                rd = _create_rdataset('CNAME', args.ttl, [newvalue], None, None, None, None)
                 creates.append((name, rd))
 
     if not deletes and not creates:
@@ -807,7 +814,7 @@ def wait_for_sync(obj):
 def cmd_rrcreate(args):
     zone = _get_records(args)
     name = dns.name.from_text(args.rr, zone.origin)
-    rdataset = _create_rdataset(args.type, args.ttl, args.values, args.weight, args.identifier, args.region)
+    rdataset = _create_rdataset(args.type, args.ttl, args.values, args.weight, args.identifier, args.region, args.failover)
 
     rdataset_old = None
     node = zone.get_node(args.rr)
@@ -953,6 +960,7 @@ def main():
     parser_rrcreate.add_argument('-w', '--weight', type=int, help='record weight')
     parser_rrcreate.add_argument('-i', '--identifier', help='record set identifier')
     parser_rrcreate.add_argument('--region', help='region for latency-based routing')
+    parser_rrcreate.add_argument('--failover', help='failover type for dns failover routing')
     parser_rrcreate.add_argument('-r', '--replace', action='store_true', help='replace any existing record')
     parser_rrcreate.add_argument('--wait', action='store_true', default=False, help='wait for changes to become live before exiting (default: false)')
     parser_rrcreate.add_argument('--dump', action='store_true', help='dump xml format to stdout')


### PR DESCRIPTION
Not sure why it's not showing both commits in the pull request -- but this would be to merge both the latest commit I made, which edits the modification methods (sorry about missing that in the last pull) to allow for failover types along with read support for failover types.