### PR TITLE
Create DNS records for instances without public addresses

### DIFF
--- a/scripts/cli53
+++ b/scripts/cli53
@@ -699,7 +699,10 @@ def cmd_instances(args):
 
         newvalue = None
         if inst.state == 'running':
-            newvalue = inst.public_dns_name
+            if inst.public_dns_name != "":
+               	newvalue = inst.public_dns_name
+            else:
+                newvalue = inst.private_dns_name
         elif args.off == 'delete':
             newvalue = None
         elif args.off and name not in creates:


### PR DESCRIPTION
If instances don't have a public address, there's no record created. This pr solves this..

I think it should be expanded on, ultimately it should really be a flag, but my python knowledge and time is a bit limited right now.
