### PR TITLE
Support failover record types (based on work of Lee-Ming Zen)

### DIFF
--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -114,6 +114,8 @@ class ZoneTest(BindTest):
                 "test3 600 AWS ALIAS region:us-west-1 Z3NF1Z3NOM5OY2 test-212960849.eu-west-1.elb.amazonaws.com. "
                 "identifier-test-id",
                 "test4 600 AWS ALIAS 50 Z3NF1Z3NOM5OY2 test-212960849.eu-west-1.elb.amazonaws.com. latency-test-id",
+                "test5 60 AWS A failover:PRIMARY 127.0.0.3 Primary",
+                "test5 600 AWS A failover:SECONDARY 127.0.0.4 Secondary"
             ],
             output
         )

--- a/tests/zoneaws.txt
+++ b/tests/zoneaws.txt
@@ -3,3 +3,5 @@ test 86400 AWS A 20 127.0.0.2 def
 test2 600 AWS ALIAS Z3NF1Z3NOM5OY2 test-212960849.eu-west-1.elb.amazonaws.com.
 test3 600 AWS ALIAS region:us-west-1 Z3NF1Z3NOM5OY2 test-212960849.eu-west-1.elb.amazonaws.com. identifier-test-id
 test4 600 AWS ALIAS 50 Z3NF1Z3NOM5OY2 test-212960849.eu-west-1.elb.amazonaws.com. latency-test-id
+test5 60 AWS A failover:PRIMARY 127.0.0.3 Primary
+test5 600 AWS A failover:SECONDARY 127.0.0.4 Secondary


### PR DESCRIPTION
This makes export work for failover records, we needed this to work for a 200+ records zone.

PR #80 allows for creation as well.