### PR TITLE
Fix purge logic for NS records

### DIFF
--- a/internal/features/commands.feature
+++ b/internal/features/commands.feature
@@ -116,3 +116,15 @@ Feature: commands
     When I run "cli53 rrcreate $domain '*.wildcard A 127.0.0.1'"
     And I run "cli53 rrdelete $domain *.wildcard A"
     Then the domain "$domain" doesn't have record "*.wildcard.$domain. 3600 IN A 127.0.0.1"
+
+  Scenario: I can purge a domain with child NS record
+    Given I have a domain "$domain"
+    When I run "cli53 rrcreate $domain 'a NS b.example.com.'"
+    And I run "cli53 rrpurge --confirm $domain"
+    Then the domain "$domain" doesn't have record "a.$domain. 3600 IN NS b.example.com."
+
+  Scenario: I can delete a domain with a child NS record
+    Given I have a domain "$domain"
+    When I run "cli53 rrcreate $domain 'a NS b.example.com.'"
+    And I run "cli53 delete --purge $domain"
+    Then the domain "$domain" is deleted


### PR DESCRIPTION
Previously, NS records would never be purged. Instead, only exclude the
required "auth" SOA and NS records from purging.

If you want a unit test for this, please provide some guidance on how/what that should look like.