### PR TITLE
Adds homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ https://github.com/barnybug/cli53/releases/latest
     $ sudo mv cli53-my-platform /usr/local/bin/cli53
     $ sudo chmod +x /usr/local/bin/cli53
 
+Alternatively, on Mac you can install it using homebrew
+
+    $ brew install cli53
+
 To configure your Amazon credentials, either place them in a file `~/.aws/credentials`:
 
 	[default]


### PR DESCRIPTION
Homebrew has merged the new formulae for cli53 in https://github.com/Homebrew/homebrew-core/pull/656

This PR adds simple instructions to install cli53 on Mac using homebrew.
This was discussed in https://github.com/barnybug/cli53/issues/139