### PR TITLE
setup Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:latest
+COPY cli53 /bin/cli53
+RUN chmod +x /bin/cli53 && apk add --no-cache openssl ca-certificates
+ENTRYPOINT ["cli53"]
+CMD ["-v"]

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,8 @@ test-coverage:
 	gocovmerge coverage/*.txt > coverage.txt
 
 test: test-unit test-integration
+
+docker-build:
+	sudo docker run --rm -v `pwd`:/go/src/github.com/barnybug/cli53 -w /go/src/github.com/barnybug/cli53 golang:1.6-alpine sh -c 'apk add --no-cache make git && make build'
+	sudo docker build -t barnybug/cli53 .
+	rm -f cli53


### PR DESCRIPTION
I completely understand if you have 0 desire to support something like this, but this code will build your app in an alpine linux environment, and then package it up in a minimal alpine container so you can use the tool from anywhere that has a running docker daemon.

An example use case is that now I could use cli53 in a build step with a build system like Drone.io where every build step is executed inside of a container.

---

So interestingly enough, I had this script be even simpler in the beginning and just copy the amd64 linux release into /bin - but for whatever reason the amd64 binary won't run? I can't seem to figure out why, musl vs glibc should have little to do with it.

---

Anyways, this is just food for thought, let me know what you think, I'm just here to help, and like I said earlier, I completely understand if this is not helping!