### PR TITLE
main.go: Indicate where zone_id can be used.

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func Main(args []string) int {
 		{
 			Name:      "delete",
 			Usage:     "delete a domain",
-			ArgsUsage: "zone",
+			ArgsUsage: "zone|zone_id",
 			Flags: append(commonFlags,
 				cli.BoolFlag{
 					Name:  "purge",
@@ -108,7 +108,7 @@ func Main(args []string) int {
 		{
 			Name:      "import",
 			Usage:     "import a bind zone file",
-			ArgsUsage: "zone",
+			ArgsUsage: "zone|zone_id",
 			Flags: append(commonFlags,
 				cli.StringFlag{
 					Name:  "file",
@@ -141,7 +141,7 @@ func Main(args []string) int {
 		{
 			Name:      "export",
 			Usage:     "export a bind zone file (to stdout)",
-			ArgsUsage: "zone",
+			ArgsUsage: "zone|zone_id",
 			Flags: append(commonFlags,
 				cli.BoolFlag{
 					Name:  "full, f",
@@ -270,7 +270,7 @@ func Main(args []string) int {
 		{
 			Name:      "rrpurge",
 			Usage:     "delete all the records (danger!)",
-			ArgsUsage: "zone",
+			ArgsUsage: "zone|zone_id",
 			Flags: append(commonFlags,
 				cli.BoolFlag{
 					Name:  "confirm",

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func Main(args []string) int {
 		{
 			Name:      "delete",
 			Usage:     "delete a domain",
-			ArgsUsage: "zone|zone_id",
+			ArgsUsage: "name|ID",
 			Flags: append(commonFlags,
 				cli.BoolFlag{
 					Name:  "purge",
@@ -108,7 +108,7 @@ func Main(args []string) int {
 		{
 			Name:      "import",
 			Usage:     "import a bind zone file",
-			ArgsUsage: "zone|zone_id",
+			ArgsUsage: "name|ID",
 			Flags: append(commonFlags,
 				cli.StringFlag{
 					Name:  "file",
@@ -141,7 +141,7 @@ func Main(args []string) int {
 		{
 			Name:      "export",
 			Usage:     "export a bind zone file (to stdout)",
-			ArgsUsage: "zone|zone_id",
+			ArgsUsage: "name|ID",
 			Flags: append(commonFlags,
 				cli.BoolFlag{
 					Name:  "full, f",
@@ -270,7 +270,7 @@ func Main(args []string) int {
 		{
 			Name:      "rrpurge",
 			Usage:     "delete all the records (danger!)",
-			ArgsUsage: "zone|zone_id",
+			ArgsUsage: "name|ID",
 			Flags: append(commonFlags,
 				cli.BoolFlag{
 					Name:  "confirm",


### PR DESCRIPTION
Clarified that import, export, delete, and rrpurge support either zone or zone_id. Using zone_id is much more efficient if it is available.