### PR TITLE
Update test for zone ID vs name (fix #197)

### DIFF
--- a/util.go
+++ b/util.go
@@ -75,7 +75,7 @@ func zoneName(s string) string {
 	return unescaper.Replace(strings.TrimRight(s, "."))
 }
 
-var reZoneId = regexp.MustCompile("^(/hostedzone/)?[A-Z0-9]{12,}$")
+var reZoneId = regexp.MustCompile("^(/hostedzone/)?[A-Z0-9]{11,}$")
 
 func isZoneId(s string) bool {
 	return reZoneId.MatchString(s)


### PR DESCRIPTION
We have found zone IDs as short as 11 characters, so the regexp was changed to match 11 or more characters instead of 12 or more.