### PR TITLE
More detailed output from `import --dry-run`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -284,12 +284,16 @@ func importBind(args importArgs) {
 		} else {
 			fmt.Println("Dry-run, changes that would be made:")
 			for _, addition := range additions {
-				rr := addition.ResourceRecordSet
-				fmt.Printf("+ %s %s\n", *rr.Name, *rr.Type)
+				rrs := ConvertRRSetToBind(addition.ResourceRecordSet)
+				for _, rr := range rrs {
+					fmt.Printf("+ %s\n", rr.String())
+				}
 			}
 			for _, deletion := range deletions {
-				rr := deletion.ResourceRecordSet
-				fmt.Printf("- %s %s\n", *rr.Name, *rr.Type)
+				rrs := ConvertRRSetToBind(deletion.ResourceRecordSet)
+				for _, rr := range rrs {
+					fmt.Printf("- %s\n", rr.String())
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Currently it print output like this:

    Dry-run, changes that would be made:
    + example.com. A
    - example.com. A

You don't get any details on what's actually changed, so you can't use that to make a decision whether it's safe to run the command without `--dry-run`. I have used the existing bind formatting functions to export the RR to the bind format and print that instead.

The new output looks like this:

    Dry-run, changes that would be made:
    + example.com.	3600	IN	A	127.0.0.1
    - example.com.	3600	IN	A	127.0.0.2

I think that is much more useful and still looks readable enough.