### PR TITLE
Add --endpoint-url similar to AWS CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ after '/hostedzone/' you can see in the output to 'cli53 list'. eg:
 
     $ cli53 rrcreate ZZZZZZZZZZZZZ 'name A 127.0.0.1'
 
+## Setting Endpoint URL
+
+Similar to the AWS CLI, the Route 53 endpoint can be set with the --endpoint-url flag. It can be a hostname or a fully qualified URL. This is particularly useful for testing.
+
+    $ cli53 list --endpoint-url "http://localhost:4580"
+
 ## Caveats
 
 As Amazon limits operations to a maximum of 100 changes, if you

--- a/internal/features/list.feature
+++ b/internal/features/list.feature
@@ -5,6 +5,17 @@ Feature: list
     When I run "cli53 list"
     Then the output contains "$domain"
 
+  Scenario: I can list domains with --endpoint-url
+    Given I have a domain "$domain"
+    When I execute "cli53 list --endpoint-url https://route53.amazonaws.com" with var AWS_REGION as "us-east-1"
+    Then the output contains "$domain"
+
+  Scenario: I try to list domains with --endpoint-url without region
+    Given I have a domain "$domain"
+    When I execute "cli53 list --endpoint-url https://route53.amazonaws.com" with var AWS_REGION as ""
+    Then the exit code was 1
+    And the output matches "AWS_REGION must be set when using --endpoint-url"
+
   Scenario: I can list domains as csv
     Given I have a domain "$domain"
     When I run "cli53 list --format csv"

--- a/main.go
+++ b/main.go
@@ -26,6 +26,10 @@ func Main(args []string) int {
 			Name:  "profile",
 			Usage: "profile to use from credentials file",
 		},
+		cli.StringFlag{
+			Name:  "endpoint-url",
+			Usage: "override Route53 endpoint (hostname or fully qualified URI)",
+		},
 	}
 
 	app := cli.NewApp()
@@ -44,8 +48,11 @@ func Main(args []string) int {
 					Usage: "output format: text, json, jl, table, csv",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) != 0 {
 					cli.ShowCommandHelp(c, "list")
 					return cli.NewExitError("No parameters expected", 1)
@@ -85,8 +92,11 @@ func Main(args []string) int {
 					Usage: "use the given delegation set",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) != 1 {
 					cli.ShowCommandHelp(c, "create")
 					return cli.NewExitError("Expected exactly 1 parameter", 1)
@@ -105,8 +115,11 @@ func Main(args []string) int {
 					Usage: "remove any existing records on the domain (otherwise deletion will fail)",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) != 1 {
 					cli.ShowCommandHelp(c, "delete")
 					return cli.NewExitError("Expected exactly 1 parameter", 1)
@@ -143,8 +156,11 @@ func Main(args []string) int {
 					Usage: "perform a trial run with no changes made",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) != 1 {
 					cli.ShowCommandHelp(c, "import")
 					return cli.NewExitError("Expected exactly 1 parameter", 1)
@@ -203,9 +219,15 @@ func Main(args []string) int {
 					Usage: "dry run - don't make any changes",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				config := getConfig(c)
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				config, err := getConfig(c)
+				if err != nil {
+					return err
+				}
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) != 1 {
 					cli.ShowCommandHelp(c, "instances")
 					return cli.NewExitError("Expected exactly 1 parameter", 1)
@@ -235,8 +257,11 @@ func Main(args []string) int {
 					Usage: "export prefixes as full names",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) != 1 {
 					cli.ShowCommandHelp(c, "export")
 					return cli.NewExitError("Expected exactly 1 parameter", 1)
@@ -296,8 +321,11 @@ func Main(args []string) int {
 					Usage: "subdivision code for geolocation routing",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) < 2 {
 					cli.ShowCommandHelp(c, "rrcreate")
 					return cli.NewExitError("Expected at least 2 parameters", 1)
@@ -344,8 +372,11 @@ func Main(args []string) int {
 					Usage: "record set identifier to delete",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) != 3 {
 					cli.ShowCommandHelp(c, "rrdelete")
 					return cli.NewExitError("Expected exactly 3 parameters", 1)
@@ -368,8 +399,11 @@ func Main(args []string) int {
 					Usage: "wait for changes to become live",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) != 1 {
 					cli.ShowCommandHelp(c, "rrpurge")
 					return cli.NewExitError("Expected exactly 1 parameter", 1)
@@ -385,8 +419,11 @@ func Main(args []string) int {
 			Name:  "dslist",
 			Usage: "list reusable delegation sets",
 			Flags: commonFlags,
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				listReusableDelegationSets()
 				return nil
 			},
@@ -401,8 +438,11 @@ func Main(args []string) int {
 					Usage: "convert the given zone delegation set (optional)",
 				},
 			),
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				createReusableDelegationSet(c.String("zone-id"))
 				return nil
 			},
@@ -412,8 +452,11 @@ func Main(args []string) int {
 			Usage:     "delete a reusable delegation set",
 			ArgsUsage: "id",
 			Flags:     commonFlags,
-			Action: func(c *cli.Context) error {
-				r53 = getService(c)
+			Action: func(c *cli.Context) (err error) {
+				r53, err = getService(c)
+				if err != nil {
+					return err
+				}
 				if len(c.Args()) != 1 {
 					cli.ShowCommandHelp(c, "dsdelete")
 					return cli.NewExitError("Expected exactly 1 parameter", 1)


### PR DESCRIPTION
Add flag --endpoint-url flag for setting Route 53 endpoint. It works the
same as --endpoint-url in the AWS CLI, taking a hostname or fully
qualified URL. AWS_REGION must be set when using this flag.