### PR TITLE
edit Readme.md add bash command to backup all zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Export as a BIND zone file (for backup!):
 
 Export all zones as a BIND zone file, concatinated. (for full backup):
 
-    $ for domain in $(cli53 list -format json | jq -r '.[].Name' | sed 's/.$//g' ); do cli53 export $domain ; done
+    $ for domain in $(cli53 list -format json | jq -r '.[].Name' | sed 's/.$//g'); do cli53 export $domain; done
 
 Create some weighted records:
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Export as a BIND zone file (for backup!):
 
 	$ cli53 export example.com
 
+Export all zones as a BIND zone file, concatinated. (for full backup):
+
+    $ for domain in $(cli53 list -format json | jq -r '.[].Name' | sed 's/.$//g' ); do cli53 export $domain ; done
+
 Create some weighted records:
 
 	$ cli53 rrcreate --identifier server1 --weight 10 example.com 'www A 192.168.0.1'


### PR DESCRIPTION
Added bash one liner to the readme. Downloads/backups all zonefiles.

I would guess this is one of the most common use cases.
It does use "jq" wich i assumed this is being used in other commands in the readme.