### PR TITLE
Minor typo fix (Bare -> bear)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ install the python cli53 by giving pip the github branch:
 
 	$ pip install git+https://github.com/barnybug/cli53.git@python
 
-Bare in mind I'll no longer be supporting this any more, so any bug reports
+Bear in mind I'll no longer be supporting this any more, so any bug reports
 will be flatly closed!
 
 ## Broken CNAME exports (GoDaddy)


### PR DESCRIPTION
Simple change to correct spelling/grammar - it's meant to be "bear in mind", not "bare in mind" :)