### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Export as a BIND zone file (for backup!):
 
 Export fully-qualified domain names (instead of just prefixes) to `stdout`, and send AWS debug logging to `stderr`:
 
-  $ cli53 export --full --debug example.com > example.com.txt 2> example.com.err.log
+    $ cli53 export --full --debug example.com > example.com.txt 2> example.com.err.log
 
 Create some weighted records:
 


### PR DESCRIPTION
This relates to #243... I use two spaces, and it was formatted as such in my editor.

Sorry again for the error, @barnybug! :P