### PR TITLE
Add export output to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ coverage.txt
 coverage/
 
 /dist/
+
+# GoLand
+.idea

--- a/commands.go
+++ b/commands.go
@@ -372,9 +372,9 @@ func UnexpandSelfAliases(records []dns.RR, zone *route53.HostedZone, full bool) 
 	}
 }
 
-func exportBind(name string, full bool) {
+func exportBind(name string, full bool, writer io.Writer) {
 	zone := lookupZone(name)
-	ExportBindToWriter(r53, zone, full, os.Stdout)
+	ExportBindToWriter(r53, zone, full, writer)
 }
 
 type exportSorter struct {

--- a/internal/features/export.feature
+++ b/internal/features/export.feature
@@ -12,3 +12,9 @@ Feature: export
     When I run "cli53 rrcreate $domain 'alias 86400 AWS ALIAS A www $self false'"
     And I run "cli53 export --full $domain"
     Then the output contains "alias.$domain.	86400	AWS	ALIAS	A www.$domain. $self false"
+
+  Scenario: I can export a domain to a file
+      Given I have a domain "$domain"
+      When I run "cli53 rrcreate $domain 'www A 127.0.0.1'"
+      And I run "cli53 export --output /tmp/testcli53 $domain"
+      Then the output file "/tmp/testcli53" contains "$domain"

--- a/internal/features/step_definitions.go
+++ b/internal/features/step_definitions.go
@@ -359,6 +359,20 @@ func init() {
 		}
 	})
 
+	Then(`^the output file "(.+?)" contains "(.+?)"$`, func(outputFile string, s string) {
+		outputFile = unquote(outputFile)
+		s = unquote(domain(s))
+		output, err := ioutil.ReadFile(outputFile)
+
+		if err != nil {
+			T.Errorf("Could not read %s", outputFile)
+		}
+
+		if !strings.Contains(string(output), s) {
+			T.Errorf("Output did not contain \"%s\"\nactual: %s", s, runOutput)
+		}
+	})
+
 	Then(`^the output matches "(.+?)"$`, func(s string) {
 		re, err := regexp.Compile(s)
 		fatalIfErr(err)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/urfave/cli"
+	"os"
 )
 
 var r53 *route53.Route53
@@ -256,6 +257,10 @@ func Main(args []string) int {
 					Name:  "full, f",
 					Usage: "export prefixes as full names",
 				},
+				cli.StringFlag{
+					Name:  "output",
+					Usage: "Write to an output file instead of STDOUT",
+				},
 			),
 			Action: func(c *cli.Context) (err error) {
 				r53, err = getService(c)
@@ -266,7 +271,17 @@ func Main(args []string) int {
 					cli.ShowCommandHelp(c, "export")
 					return cli.NewExitError("Expected exactly 1 parameter", 1)
 				}
-				exportBind(c.Args().First(), c.Bool("full"))
+
+				outputFileName := c.String("output")
+				writer := os.Stdout
+				if len(outputFileName) > 0 {
+					writer, err = os.Create(outputFileName)
+					defer writer.Close()
+					if err != nil {
+						return err
+					}
+				}
+				exportBind(c.Args().First(), c.Bool("full"), writer)
 				return nil
 			},
 		},


### PR DESCRIPTION
# Goal

To make possible to export the output into a file instead of `os.Stdout`. 

# Why? You could use a redirection operator `>`

Yes, you can use a redirection for that (`> myfile`) but if you plan to use `r53cli` as a library instead of using it directly as a CLI, it complicates whatever you want to do unnecessarily. 


- [x] make sure changes are up to date with master
- [x] please use brief, descriptive commit messages 
- [x] check code has been go formatted with `go fmt` 
- [x] ensure you've added an integration test (under internal/features) or a unit test
- [x] check the tests pass (make test)

