### PR TITLE
Fixing import not updating aliases

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -251,6 +251,9 @@ func rrsetKey(rrset *route53.ResourceRecordSet) string {
 	for _, rr := range rrset.ResourceRecords {
 		rrs = append(rrs, rr.String())
 	}
+	if rrset.AliasTarget != nil {
+		rrs = append(rrs, rrset.AliasTarget.String())
+	}
 	sort.Strings(rrs)
 	for _, rr := range rrs {
 		key += " " + rr

--- a/tests/replace1.txt
+++ b/tests/replace1.txt
@@ -9,4 +9,6 @@ mail 86400 IN A 10.0.0.2
 mail2 86400 IN A 10.0.0.3
 test 86400 IN TXT "multivalued" " txt \"quoted\" record"
 www 86400 IN A 10.0.0.1
+www2 86400 IN A 10.0.0.1
 unchanged 86400 IN A 10.1.0.1
+alias	86400	AWS	ALIAS	A www $self false

--- a/tests/replace2.txt
+++ b/tests/replace2.txt
@@ -9,4 +9,6 @@ mail 86400 IN A 10.0.0.4
 mail2 86400 IN A 10.0.0.5
 test 86400 IN TXT "one"
 www 86400 IN A 10.0.0.2
+www2 86400 IN A 10.0.0.2
 unchanged 86400 IN A 10.1.0.1
+alias	86400	AWS	ALIAS	A www2 $self false


### PR DESCRIPTION
This addresses https://github.com/barnybug/cli53/issues/268. I'm very new to Go so if there are any updates to the tests required here, I'm open suggestions.

It looks like a couple of tests failed but that is due to a hard coded VPC id. The output is below. Thanks.

```
$ make test
go test
PASS
ok  	github.com/barnybug/cli53	0.005s
go build -i -v ./cmd/cli53
gucumber
@create
Feature: create
  Scenario: I can create a domain                   # internal/features/create.feature:2
    When I run "cli53 create $domain --comment hi"  # internal/features/create.feature:3
    Then the domain "$domain" is created            # internal/features/create.feature:4

  Scenario: I can create a domain period             # internal/features/create.feature:6
    When I run "cli53 create $domain. --comment hi"  # internal/features/create.feature:7
    Then the domain "$domain" is created             # internal/features/create.feature:8

  Scenario: I can create a VPC private domain                                                    # internal/features/create.feature:10
    When I run "cli53 create $domain --comment hi --vpc-id vpc-d70f05b5 --vpc-region eu-west-1"  # internal/features/create.feature:11

Error: exit status 1 Output: Error: InvalidVPCId: The VPC: vpc-d70f05b5 you provided is not authorized to make the association.
	status code: 400, request id: 4a836c77-23f4-11e9-bca5-934794919dec

    Then the domain "$domain" is created                                                         # internal/features/create.feature:14

@delegationSets
Feature: reusable delegation sets
  Scenario: I can create with a delegation set                            # internal/features/delegationSets.feature:2
    Given I have a delegation set                                         # internal/features/delegationSets.feature:3
    When I run "cli53 create $domain --delegation-set-id $delegationSet"  # internal/features/delegationSets.feature:4
    Then the domain "$domain" is created                                  # internal/features/delegationSets.feature:5

  Scenario: I can create a delegation set                                 # internal/features/delegationSets.feature:7
    When I run "cli53 dscreate"                                           # internal/features/delegationSets.feature:8
    Then the output matches "Created reusable delegation set ID: '(.+)'"  # internal/features/delegationSets.feature:9
    And the delegation set "$1" is created                                # internal/features/delegationSets.feature:10

  Scenario: I can delete a delegation set                # internal/features/delegationSets.feature:12
    Given I have a delegation set                        # internal/features/delegationSets.feature:13
    When I run "cli53 dsdelete $delegationSet"           # internal/features/delegationSets.feature:14
    Then the delegation set "$delegationSet" is deleted  # internal/features/delegationSets.feature:15

  Scenario: I can list delegation sets when there none    # internal/features/delegationSets.feature:17
    When I run "cli53 dslist"                             # internal/features/delegationSets.feature:18
    Then the output contains "none"                       # internal/features/delegationSets.feature:19

  Scenario: I can list delegation sets with one       # internal/features/delegationSets.feature:21
    Given I have a delegation set                     # internal/features/delegationSets.feature:22
    When I run "cli53 dslist"                         # internal/features/delegationSets.feature:23
    Then the output contains "- ID: /delegationset/"  # internal/features/delegationSets.feature:26

@delete
Feature: delete
  Scenario: I can delete a domain by name    # internal/features/delete.feature:2
    Given I have a domain "$domain"          # internal/features/delete.feature:3
    When I run "cli53 delete $domain"        # internal/features/delete.feature:4
    Then the domain "$domain" is deleted     # internal/features/delete.feature:5

  Scenario: I can delete a domain by name period    # internal/features/delete.feature:7
    Given I have a domain "$domain"                 # internal/features/delete.feature:8
    When I run "cli53 delete $domain."              # internal/features/delete.feature:9
    Then the domain "$domain" is deleted            # internal/features/delete.feature:10

  Scenario: I can delete and purge a big domain             # internal/features/delete.feature:12
    Given I have a domain "$domain"                         # internal/features/delete.feature:13
    When I run "cli53 import --file tests/big.txt $domain"  # internal/features/delete.feature:14
    And I run "cli53 delete --purge $domain"                # internal/features/delete.feature:15
    Then the domain "$domain" is deleted                    # internal/features/delete.feature:16

  Scenario: I can delete a domain with a child NS record       # internal/features/delete.feature:18
    Given I have a domain "$domain"                            # internal/features/delete.feature:19
    When I run "cli53 rrcreate $domain 'a NS b.example.com.'"  # internal/features/delete.feature:20
    And I run "cli53 delete --purge $domain"                   # internal/features/delete.feature:21
    Then the domain "$domain" is deleted                       # internal/features/delete.feature:24

@domain
Feature: domain management
  Scenario: I can create a domain                   # internal/features/domain.feature:2
    When I run "cli53 create $domain --comment hi"  # internal/features/domain.feature:3
    Then the domain "$domain" is created            # internal/features/domain.feature:4

  Scenario: I can create a domain period             # internal/features/domain.feature:6
    When I run "cli53 create $domain. --comment hi"  # internal/features/domain.feature:7
    Then the domain "$domain" is created             # internal/features/domain.feature:8

  Scenario: I can create a VPC private domain                                                    # internal/features/domain.feature:10
    When I run "cli53 create $domain --comment hi --vpc-id vpc-d70f05b5 --vpc-region eu-west-1"  # internal/features/domain.feature:11

Error: exit status 1 Output: Error: InvalidVPCId: The VPC: vpc-d70f05b5 you provided is not authorized to make the association.
	status code: 400, request id: 4f9c0cf9-23f4-11e9-9f9f-55c2816cbf1e

    Then the domain "$domain" is created                                                         # internal/features/domain.feature:12

  Scenario: I can delete a domain by name    # internal/features/domain.feature:14
    Given I have a domain "$domain"          # internal/features/domain.feature:15
    When I run "cli53 delete $domain"        # internal/features/domain.feature:16
    Then the domain "$domain" is deleted     # internal/features/domain.feature:17

  Scenario: I can delete a domain by name period    # internal/features/domain.feature:19
    Given I have a domain "$domain"                 # internal/features/domain.feature:20
    When I run "cli53 delete $domain."              # internal/features/domain.feature:21
    Then the domain "$domain" is deleted            # internal/features/domain.feature:22

  Scenario: I can delete and purge a big domain             # internal/features/domain.feature:24
    Given I have a domain "$domain"                         # internal/features/domain.feature:25
    When I run "cli53 import --file tests/big.txt $domain"  # internal/features/domain.feature:26
    And I run "cli53 delete --purge $domain"                # internal/features/domain.feature:27
    Then the domain "$domain" is deleted                    # internal/features/domain.feature:28

  Scenario: I can list domains          # internal/features/domain.feature:30
    Given I have a domain "$domain"     # internal/features/domain.feature:31
    When I run "cli53 list"             # internal/features/domain.feature:32
    Then the output contains "$domain"  # internal/features/domain.feature:33

  Scenario: I can purge a domain                                                    # internal/features/domain.feature:35
    Given I have a domain "$domain"                                                 # internal/features/domain.feature:36
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1'"                             # internal/features/domain.feature:37
    And I run "cli53 rrpurge --confirm $domain"                                     # internal/features/domain.feature:38
    Then the domain "$domain" doesn't have record "a.$domain. 3600 IN A 127.0.0.1"  # internal/features/domain.feature:39

  Scenario: I can purge a domain with wildcard records                                       # internal/features/domain.feature:41
    Given I have a domain "$domain"                                                          # internal/features/domain.feature:42
    When I run "cli53 rrcreate $domain '*.wildcard A 127.0.0.1'"                             # internal/features/domain.feature:43
    And I run "cli53 rrpurge --confirm $domain"                                              # internal/features/domain.feature:44
    Then the domain "$domain" doesn't have record "*.wildcard.$domain. 3600 IN A 127.0.0.1"  # internal/features/domain.feature:45

  Scenario: I can export a domain                        # internal/features/domain.feature:47
    Given I have a domain "$domain"                      # internal/features/domain.feature:48
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1'"  # internal/features/domain.feature:49
    And I run "cli53 export $domain"                     # internal/features/domain.feature:50
    Then the output contains "$domain"                   # internal/features/domain.feature:51

  Scenario: I can export a domain --full                                                  # internal/features/domain.feature:53
    Given I have a domain "$domain"                                                       # internal/features/domain.feature:54
    When I run "cli53 rrcreate $domain 'www A 127.0.0.1'"                                 # internal/features/domain.feature:55
    When I run "cli53 rrcreate $domain 'alias 86400 AWS ALIAS A www $self false'"         # internal/features/domain.feature:56
    And I run "cli53 export --full $domain"                                               # internal/features/domain.feature:57
    Then the output contains "alias.$domain.	86400	AWS	ALIAS	A www.$domain. $self false"  # internal/features/domain.feature:60

@export
Feature: export
  Scenario: I can export a domain                        # internal/features/export.feature:2
    Given I have a domain "$domain"                      # internal/features/export.feature:3
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1'"  # internal/features/export.feature:4
    And I run "cli53 export $domain"                     # internal/features/export.feature:5
    Then the output contains "$domain"                   # internal/features/export.feature:6

  Scenario: I can export a domain --full                                                  # internal/features/export.feature:8
    Given I have a domain "$domain"                                                       # internal/features/export.feature:9
    When I run "cli53 rrcreate $domain 'www A 127.0.0.1'"                                 # internal/features/export.feature:10
    When I run "cli53 rrcreate $domain 'alias 86400 AWS ALIAS A www $self false'"         # internal/features/export.feature:11
    And I run "cli53 export --full $domain"                                               # internal/features/export.feature:12
    Then the output contains "alias.$domain.	86400	AWS	ALIAS	A www.$domain. $self false"  # internal/features/export.feature:13

  Scenario: I can export a domain to a file                   # internal/features/export.feature:15
    Given I have a domain "$domain"                           # internal/features/export.feature:16
    When I run "cli53 rrcreate $domain 'www A 127.0.0.1'"     # internal/features/export.feature:17
    And I run "cli53 export --output /tmp/testcli53 $domain"  # internal/features/export.feature:18
    Then the output file "/tmp/testcli53" contains "$domain"  # internal/features/export.feature:21

@import
Feature: import
  Scenario: I can import a wildcard zone                                # internal/features/import.feature:2
    Given I have a domain "$domain"                                     # internal/features/import.feature:3
    When I run "cli53 import --file tests/wildcard.txt $domain"         # internal/features/import.feature:4
    Then the domain "$domain" export matches file "tests/wildcard.txt"  # internal/features/import.feature:5

  Scenario: I can import a basic zone                                # internal/features/import.feature:7
    Given I have a domain "$domain"                                  # internal/features/import.feature:8
    When I run "cli53 import --file tests/basic.txt $domain"         # internal/features/import.feature:9
    Then the domain "$domain" export matches file "tests/basic.txt"  # internal/features/import.feature:10

  Scenario: I can import an arpa zone                                           # internal/features/import.feature:12
    Given I have a domain "0.1.10.in-addr.arpa"                                 # internal/features/import.feature:13
    When I run "cli53 import --file tests/arpa.txt 0.1.10.in-addr.arpa"         # internal/features/import.feature:14
    Then the domain "0.1.10.in-addr.arpa" export matches file "tests/arpa.txt"  # internal/features/import.feature:15

  Scenario: I can import a big zone                                # internal/features/import.feature:17
    Given I have a domain "$domain"                                # internal/features/import.feature:18
    When I run "cli53 import --file tests/big.txt $domain"         # internal/features/import.feature:19
    Then the domain "$domain" export matches file "tests/big.txt"  # internal/features/import.feature:20

  Scenario: I can import a big zone with identifiers                # internal/features/import.feature:22
    Given I have a domain "$domain"                                 # internal/features/import.feature:23
    When I run "cli53 import --file tests/big2.txt $domain"         # internal/features/import.feature:24
    Then the domain "$domain" export matches file "tests/big2.txt"  # internal/features/import.feature:25

  Scenario: I can import a zone with failover extensions                # internal/features/import.feature:27
    Given I have a domain "$domain"                                     # internal/features/import.feature:28
    When I run "cli53 import --file tests/failover.txt $domain"         # internal/features/import.feature:29
    Then the domain "$domain" export matches file "tests/failover.txt"  # internal/features/import.feature:30

  Scenario: I can import a zone with geo extensions                # internal/features/import.feature:32
    Given I have a domain "$domain"                                # internal/features/import.feature:33
    When I run "cli53 import --file tests/geo.txt $domain"         # internal/features/import.feature:34
    Then the domain "$domain" export matches file "tests/geo.txt"  # internal/features/import.feature:35

  Scenario: I can import a zone with latency extensions                # internal/features/import.feature:42
    Given I have a domain "$domain"                                    # internal/features/import.feature:43
    When I run "cli53 import --file tests/latency.txt $domain"         # internal/features/import.feature:44
    Then the domain "$domain" export matches file "tests/latency.txt"  # internal/features/import.feature:45

  Scenario: I can import a zone with weighted extensions                # internal/features/import.feature:47
    Given I have a domain "$domain"                                     # internal/features/import.feature:48
    When I run "cli53 import --file tests/weighted.txt $domain"         # internal/features/import.feature:49
    Then the domain "$domain" export matches file "tests/weighted.txt"  # internal/features/import.feature:50

  @multivalue
  Scenario: I can import a zone with multivalue answer extensions         # internal/features/import.feature:53
    Given I have a domain "$domain"                                       # internal/features/import.feature:54
    When I run "cli53 import --file tests/multivalue.txt $domain"         # internal/features/import.feature:55
    Then the domain "$domain" export matches file "tests/multivalue.txt"  # internal/features/import.feature:56

  Scenario: I can import a zone with alias extensions                # internal/features/import.feature:58
    Given I have a domain "$domain"                                  # internal/features/import.feature:59
    When I run "cli53 import --file tests/alias.txt $domain"         # internal/features/import.feature:60
    Then the domain "$domain" export matches file "tests/alias.txt"  # internal/features/import.feature:61

  Scenario: I can import a zone with an alias with multiple types                   # internal/features/import.feature:63
    Given I have a domain "$domain"                                                 # internal/features/import.feature:64
    When I run "cli53 import --file tests/alias_multiple_types.txt $domain"         # internal/features/import.feature:65
    Then the domain "$domain" export matches file "tests/alias_multiple_types.txt"  # internal/features/import.feature:66

  Scenario: I can import (replace) a zone                                 # internal/features/import.feature:68
    Given I have a domain "$domain"                                       # internal/features/import.feature:69
    When I run "cli53 import --file tests/replace1.txt $domain"           # internal/features/import.feature:70
    And I run "cli53 import --replace --file tests/replace2.txt $domain"  # internal/features/import.feature:71
    Then the domain "$domain" export matches file "tests/replace2.txt"    # internal/features/import.feature:72

  Scenario: I can import dry-run (with changes)                                     # internal/features/import.feature:74
    Given I have a domain "$domain"                                                 # internal/features/import.feature:75
    When I run "cli53 import --file tests/replace1.txt $domain"                     # internal/features/import.feature:76
    And I run "cli53 import --replace --file tests/replace2.txt --dry-run $domain"  # internal/features/import.feature:77
    Then the output contains "Dry-run"                                              # internal/features/import.feature:78
    And the output contains "+ mail.$domain.	86400	IN	A	10.0.0.4"                   # internal/features/import.feature:79
    And the output contains "- mail.$domain.	86400	IN	A	10.0.0.2"                   # internal/features/import.feature:80

  Scenario: I can import dry-run (no changes)                                       # internal/features/import.feature:82
    Given I have a domain "$domain"                                                 # internal/features/import.feature:83
    When I run "cli53 import --file tests/replace1.txt $domain"                     # internal/features/import.feature:84
    And I run "cli53 import --replace --file tests/replace1.txt --dry-run $domain"  # internal/features/import.feature:85
    Then the output contains "no changes would have been made"                      # internal/features/import.feature:86

  Scenario: I can import a zone editing auth                                       # internal/features/import.feature:88
    Given I have a domain "$domain"                                                # internal/features/import.feature:89
    When I run "cli53 import --file tests/auth.txt --replace --editauth $domain"   # internal/features/import.feature:90
    Then the domain "$domain" export matches file "tests/auth.txt" including auth  # internal/features/import.feature:91

  Scenario: I can import a zone with no changes                           # internal/features/import.feature:93
    Given I have a domain "$domain"                                       # internal/features/import.feature:94
    When I run "cli53 import --file tests/replace1.txt $domain"           # internal/features/import.feature:95
    And I run "cli53 import --replace --file tests/replace1.txt $domain"  # internal/features/import.feature:96
    Then the output contains "0 changes"                                  # internal/features/import.feature:97

  Scenario: I can import a zone with a wildcard record with no changes    # internal/features/import.feature:99
    Given I have a domain "$domain"                                       # internal/features/import.feature:100
    When I run "cli53 import --file tests/replace3.txt $domain"           # internal/features/import.feature:101
    And I run "cli53 import --replace --file tests/replace3.txt $domain"  # internal/features/import.feature:102
    Then the output contains "0 changes"                                  # internal/features/import.feature:103

  Scenario: I can import a zone as case-insensitive                        # internal/features/import.feature:105
    Given I have a domain "$domain"                                        # internal/features/import.feature:106
    When I run "cli53 import --file tests/uppercase.txt $domain"           # internal/features/import.feature:107
    And I run "cli53 import --replace --file tests/uppercase.txt $domain"  # internal/features/import.feature:108
    Then the output contains "0 changes"                                   # internal/features/import.feature:111

@list
Feature: list
  Scenario: I can list domains          # internal/features/list.feature:2
    Given I have a domain "$domain"     # internal/features/list.feature:3
    When I run "cli53 list"             # internal/features/list.feature:4
    Then the output contains "$domain"  # internal/features/list.feature:5

  Scenario: I can list domains with --endpoint-url                                                               # internal/features/list.feature:7
    Given I have a domain "$domain"                                                                              # internal/features/list.feature:8
    When I execute "cli53 list --endpoint-url https://route53.amazonaws.com" with var AWS_REGION as "us-east-1"  # internal/features/list.feature:9
    Then the output contains "$domain"                                                                           # internal/features/list.feature:10

  Scenario: I try to list domains with --endpoint-url without region                                    # internal/features/list.feature:12
    Given I have a domain "$domain"                                                                     # internal/features/list.feature:13
    When I execute "cli53 list --endpoint-url https://route53.amazonaws.com" with var AWS_REGION as ""  # internal/features/list.feature:14
    Then the exit code was 1                                                                            # internal/features/list.feature:15
    And the output matches "AWS_REGION must be set when using --endpoint-url"                           # internal/features/list.feature:16

  Scenario: I can list domains as csv                        # internal/features/list.feature:18
    Given I have a domain "$domain"                          # internal/features/list.feature:19
    When I run "cli53 list --format csv"                     # internal/features/list.feature:20
    Then the output contains "id,name,record count,comment"  # internal/features/list.feature:21
    And the output contains "$domain.,2,"                    # internal/features/list.feature:22

  Scenario: I can list domains as json     # internal/features/list.feature:24
    Given I have a domain "$domain"        # internal/features/list.feature:25
    When I run "cli53 list --format json"  # internal/features/list.feature:26
    Then the output contains "[{"          # internal/features/list.feature:27
    And the output contains "$domain"      # internal/features/list.feature:28
    And the output contains "}]"           # internal/features/list.feature:29

  Scenario: I can list domains as jl     # internal/features/list.feature:31
    Given I have a domain "$domain"      # internal/features/list.feature:32
    When I run "cli53 list --format jl"  # internal/features/list.feature:33
    Then the output contains "{"         # internal/features/list.feature:34
    And the output contains "$domain"    # internal/features/list.feature:35
    And the output contains "}"          # internal/features/list.feature:36

  Scenario: I can list domains as text             # internal/features/list.feature:38
    Given I have a domain "$domain"                # internal/features/list.feature:39
    When I run "cli53 list --format text"          # internal/features/list.feature:40
    Then the output contains "Name: \"$domain.\""  # internal/features/list.feature:41

  Scenario: I can list domains as table                        # internal/features/list.feature:43
    Given I have a domain "$domain"                            # internal/features/list.feature:44
    When I run "cli53 list --format table"                     # internal/features/list.feature:45
    Then the output matches "ID +Name +Record count +Comment"  # internal/features/list.feature:46
    And the output contains "$domain. 2"                       # internal/features/list.feature:47

  Scenario: list validates format parameter    # internal/features/list.feature:49
    Given I have a domain "$domain"            # internal/features/list.feature:50
    When I execute "cli53 list --format x"     # internal/features/list.feature:51
    Then the exit code was 1                   # internal/features/list.feature:54

@rrcreate
Feature: rrcreate
  Scenario: I can create a wildcard record                                 # internal/features/rrcreate.feature:2
    Given I have a domain "$domain"                                        # internal/features/rrcreate.feature:3
    When I run "cli53 rrcreate $domain '* A 127.0.0.1'"                    # internal/features/rrcreate.feature:4
    Then the domain "$domain" has record "*.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrcreate.feature:5

  Scenario: I can create a resource record                                 # internal/features/rrcreate.feature:7
    Given I have a domain "$domain"                                        # internal/features/rrcreate.feature:8
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1'"                    # internal/features/rrcreate.feature:9
    Then the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrcreate.feature:10

  Scenario: I can create a resource record (full)                          # internal/features/rrcreate.feature:12
    Given I have a domain "$domain"                                        # internal/features/rrcreate.feature:13
    When I run "cli53 rrcreate $domain 'a.$domain. A 127.0.0.1'"           # internal/features/rrcreate.feature:14
    Then the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrcreate.feature:15

  Scenario: I can create a failover record                                                                                                                                                               # internal/features/rrcreate.feature:17
    Given I have a domain "$domain"                                                                                                                                                                      # internal/features/rrcreate.feature:18
    When I run "cli53 rrcreate -i "The First" --failover PRIMARY --health-check 6bb57c41-879a-42d0-acdd-ed6472f08eb9 $domain 'failover 300 IN A 127.0.0.1'"                                              # internal/features/rrcreate.feature:19
    Then the domain "$domain" has record "failover.$domain. 300 IN A 127.0.0.1 ; AWS routing="FAILOVER" failover="PRIMARY" healthCheckId="6bb57c41-879a-42d0-acdd-ed6472f08eb9" identifier="The First""  # internal/features/rrcreate.feature:20

  Scenario: I can create a geolocation record                                                                                                  # internal/features/rrcreate.feature:22
    Given I have a domain "$domain"                                                                                                            # internal/features/rrcreate.feature:23
    When I run "cli53 rrcreate -i Africa --continent-code AF $domain 'geo 300 IN A 127.0.0.1'"                                                 # internal/features/rrcreate.feature:24
    Then the domain "$domain" has record "geo.$domain. 300 IN A 127.0.0.1 ; AWS routing="GEOLOCATION" continentCode="AF" identifier="Africa""  # internal/features/rrcreate.feature:25

  Scenario: I can create a geolocation record with a country code and subdivision code                                                                                # internal/features/rrcreate.feature:27
    Given I have a domain "$domain"                                                                                                                                   # internal/features/rrcreate.feature:28
    When I run "cli53 rrcreate -i California --country-code US --subdivision-code CA $domain 'geo 300 IN A 127.0.0.1'"                                                # internal/features/rrcreate.feature:29
    Then the domain "$domain" has record "geo.$domain. 300 IN A 127.0.0.1 ; AWS routing="GEOLOCATION" countryCode="US" subdivisionCode="CA" identifier="California""  # internal/features/rrcreate.feature:30

  Scenario: I can create a latency record                                                                                                       # internal/features/rrcreate.feature:32
    Given I have a domain "$domain"                                                                                                             # internal/features/rrcreate.feature:33
    When I run "cli53 rrcreate -i USWest1 --region us-west-1 $domain 'latency 300 IN A 127.0.0.1'"                                              # internal/features/rrcreate.feature:34
    Then the domain "$domain" has record "latency.$domain. 300 IN A 127.0.0.1 ; AWS routing="LATENCY" region="us-west-1" identifier="USWest1""  # internal/features/rrcreate.feature:35

  Scenario: I can create a weighted record                                                                                          # internal/features/rrcreate.feature:37
    Given I have a domain "$domain"                                                                                                 # internal/features/rrcreate.feature:38
    When I run "cli53 rrcreate -i One --weight 1 $domain 'weighted 300 IN A 127.0.0.1'"                                             # internal/features/rrcreate.feature:39
    Then the domain "$domain" has record "weighted.$domain. 300 IN A 127.0.0.1 ; AWS routing="WEIGHTED" weight=1 identifier="One""  # internal/features/rrcreate.feature:40

  Scenario: I can create a weighted record with zero weight                                                                          # internal/features/rrcreate.feature:42
    Given I have a domain "$domain"                                                                                                  # internal/features/rrcreate.feature:43
    When I run "cli53 rrcreate -i Zero --weight 0 $domain 'weighted 300 IN A 127.0.0.1'"                                             # internal/features/rrcreate.feature:44
    Then the domain "$domain" has record "weighted.$domain. 300 IN A 127.0.0.1 ; AWS routing="WEIGHTED" weight=0 identifier="Zero""  # internal/features/rrcreate.feature:45

  @multivalue
  Scenario: I can create a multivalue answer record                                                                            # internal/features/rrcreate.feature:48
    Given I have a domain "$domain"                                                                                            # internal/features/rrcreate.feature:49
    When I run "cli53 rrcreate -i One --multivalue $domain 'multivalue 300 IN A 127.0.0.1'"                                    # internal/features/rrcreate.feature:50
    Then the domain "$domain" has record "multivalue.$domain. 300 IN A 127.0.0.1 ; AWS routing="MULTIVALUE" identifier="One""  # internal/features/rrcreate.feature:51

  Scenario: I can create an alias                                                            # internal/features/rrcreate.feature:53
    Given I have a domain "$domain"                                                          # internal/features/rrcreate.feature:54
    When I run "cli53 rrcreate $domain 'www A 127.0.0.1'"                                    # internal/features/rrcreate.feature:55
    When I run "cli53 rrcreate $domain 'alias 86400 AWS ALIAS A www $self false'"            # internal/features/rrcreate.feature:56
    Then the domain "$domain" has record "alias.$domain. 86400 AWS ALIAS A www $self false"  # internal/features/rrcreate.feature:57

  Scenario: I can create a round robin A record                            # internal/features/rrcreate.feature:59
    Given I have a domain "$domain"                                        # internal/features/rrcreate.feature:60
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1' 'a A 127.0.0.2'"    # internal/features/rrcreate.feature:61
    Then the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrcreate.feature:62
    And the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.2"   # internal/features/rrcreate.feature:63

  Scenario: I can create an MX record with multiple entries                                  # internal/features/rrcreate.feature:65
    Given I have a domain "$domain"                                                          # internal/features/rrcreate.feature:66
    When I run "cli53 rrcreate $domain 'mail MX 10 mailserver1.' 'mail MX 20 mailserver2.'"  # internal/features/rrcreate.feature:67
    Then the domain "$domain" has record "mail.$domain. 3600 IN MX 10 mailserver1."          # internal/features/rrcreate.feature:68
    And the domain "$domain" has record "mail.$domain. 3600 IN MX 20 mailserver2."           # internal/features/rrcreate.feature:69

  Scenario: I can create a TXT record with multiple values                   # internal/features/rrcreate.feature:71
    Given I have a domain "$domain"                                          # internal/features/rrcreate.feature:72
    When I run "cli53 rrcreate $domain 'txt TXT "a" "b"'"                    # internal/features/rrcreate.feature:73
    Then the domain "$domain" has record "txt.$domain. 3600 IN TXT "a" "b""  # internal/features/rrcreate.feature:74
    And the domain "$domain" has 3 records                                   # internal/features/rrcreate.feature:75

  Scenario: I cannot create the same resource record         # internal/features/rrcreate.feature:78
    Given I have a domain "$domain"                          # internal/features/rrcreate.feature:79
    And I run "cli53 rrcreate $domain 'a A 127.0.0.1'"       # internal/features/rrcreate.feature:80
    When I execute "cli53 rrcreate $domain 'a A 127.0.0.2'"  # internal/features/rrcreate.feature:81
    Then the exit code was 1                                 # internal/features/rrcreate.feature:82
    And the output contains "already exists"                 # internal/features/rrcreate.feature:83

  Scenario: I can append a resource record that does not exists            # internal/features/rrcreate.feature:85
    Given I have a domain "$domain"                                        # internal/features/rrcreate.feature:86
    When I run "cli53 rrcreate --append $domain 'a A 127.0.0.1'"           # internal/features/rrcreate.feature:87
    Then the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrcreate.feature:88

  Scenario: I can append a resource record that already exists             # internal/features/rrcreate.feature:90
    Given I have a domain "$domain"                                        # internal/features/rrcreate.feature:91
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1'"                    # internal/features/rrcreate.feature:92
    And I run "cli53 rrcreate --append $domain 'a A 127.0.0.2'"            # internal/features/rrcreate.feature:93
    Then the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrcreate.feature:94
    And the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.2"   # internal/features/rrcreate.feature:95

  Scenario: I cannot append the same resource record                  # internal/features/rrcreate.feature:97
    Given I have a domain "$domain"                                   # internal/features/rrcreate.feature:98
    And I run "cli53 rrcreate $domain 'a A 127.0.0.1'"                # internal/features/rrcreate.feature:99
    When I execute "cli53 rrcreate --append $domain 'a A 127.0.0.1'"  # internal/features/rrcreate.feature:100
    Then the exit code was 1                                          # internal/features/rrcreate.feature:101
    And the output contains "Duplicate Resource Record"               # internal/features/rrcreate.feature:102

  Scenario: I can replace a resource record                                # internal/features/rrcreate.feature:104
    Given I have a domain "$domain"                                        # internal/features/rrcreate.feature:105
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1'"                    # internal/features/rrcreate.feature:106
    And I run "cli53 rrcreate --replace $domain 'a A 127.0.0.2'"           # internal/features/rrcreate.feature:107
    Then the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.2"  # internal/features/rrcreate.feature:108

  Scenario: replace is case-insensitive                                         # internal/features/rrcreate.feature:110
    Given I have a domain "$domain"                                             # internal/features/rrcreate.feature:111
    When I run "cli53 rrcreate $domain 'record A 127.0.0.1'"                    # internal/features/rrcreate.feature:112
    And I run "cli53 rrcreate --replace $domain 'Record A 127.0.0.2'"           # internal/features/rrcreate.feature:113
    Then the domain "$domain" has record "record.$domain. 3600 IN A 127.0.0.2"  # internal/features/rrcreate.feature:114

  Scenario: I can replace multiple records                                                                  # internal/features/rrcreate.feature:116
    Given I have a domain "$domain"                                                                         # internal/features/rrcreate.feature:117
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1' 'mail MX 5 mailserver0.' 'mail MX 10 mailserver1.'"  # internal/features/rrcreate.feature:118
    And I run "cli53 rrcreate --replace $domain 'a A 127.0.0.2' 'mail MX 20 mailserver2.'"                  # internal/features/rrcreate.feature:119
    Then the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.2"                                   # internal/features/rrcreate.feature:120
    And the domain "$domain" has record "mail.$domain. 3600 IN MX 20 mailserver2."                          # internal/features/rrcreate.feature:121

  Scenario: I can replace a weighted record                                                                                   # internal/features/rrcreate.feature:123
    Given I have a domain "$domain"                                                                                           # internal/features/rrcreate.feature:124
    When I run "cli53 rrcreate -i One --weight 1 $domain 'a A 127.0.0.1'"                                                     # internal/features/rrcreate.feature:125
    And I run "cli53 rrcreate -i Two --weight 2 $domain 'a A 127.0.0.2'"                                                      # internal/features/rrcreate.feature:126
    And I run "cli53 rrcreate --replace -i One --weight 3 $domain 'a A 127.1.0.1'"                                            # internal/features/rrcreate.feature:127
    Then the domain "$domain" has record "a.$domain. 3600 IN A 127.1.0.1 ; AWS routing="WEIGHTED" weight=3 identifier="One""  # internal/features/rrcreate.feature:128
    And the domain "$domain" has record "a.$domain. 3600 IN A 127.0.0.2 ; AWS routing="WEIGHTED" weight=2 identifier="Two""   # internal/features/rrcreate.feature:129

  Scenario: I can replace a wildcard record                                         # internal/features/rrcreate.feature:131
    Given I have a domain "$domain"                                                 # internal/features/rrcreate.feature:132
    When I run "cli53 rrcreate $domain '*.wildcard A 127.0.0.1'"                    # internal/features/rrcreate.feature:133
    And I run "cli53 rrcreate --replace $domain '*.wildcard A 127.0.0.2'"           # internal/features/rrcreate.feature:134
    Then the domain "$domain" has record "*.wildcard.$domain. 3600 IN A 127.0.0.2"  # internal/features/rrcreate.feature:137

@rrdelete
Feature: rrdelete
  Scenario: I can delete a resource record                                          # internal/features/rrdelete.feature:2
    Given I have a domain "$domain"                                                 # internal/features/rrdelete.feature:3
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1'"                             # internal/features/rrdelete.feature:4
    And I run "cli53 rrdelete $domain a A"                                          # internal/features/rrdelete.feature:5
    Then the domain "$domain" doesn't have record "a.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrdelete.feature:6

  Scenario: I can delete a resource record by identifier                                                                                     # internal/features/rrdelete.feature:8
    Given I have a domain "$domain"                                                                                                          # internal/features/rrdelete.feature:9
    When I run "cli53 rrcreate -i One --weight 1 $domain 'weighted.$domain. 300 IN A 127.0.0.1'"                                             # internal/features/rrdelete.feature:10
    And I run "cli53 rrcreate -i Two --weight 2 $domain 'weighted.$domain. 300 IN A 127.0.0.2'"                                              # internal/features/rrdelete.feature:11
    And I run "cli53 rrdelete -i One $domain weighted A"                                                                                     # internal/features/rrdelete.feature:12
    Then the domain "$domain" doesn't have record "weighted.$domain. 300 IN A 127.0.0.1 ; AWS routing="WEIGHTED" weight=1 identifier="One""  # internal/features/rrdelete.feature:13
    And the domain "$domain" has record "weighted.$domain. 300 IN A 127.0.0.2 ; AWS routing="WEIGHTED" weight=2 identifier="Two""            # internal/features/rrdelete.feature:14

  Scenario: I can delete a wildcard record                                                   # internal/features/rrdelete.feature:16
    Given I have a domain "$domain"                                                          # internal/features/rrdelete.feature:17
    When I run "cli53 rrcreate $domain '*.wildcard A 127.0.0.1'"                             # internal/features/rrdelete.feature:18
    And I run "cli53 rrdelete $domain *.wildcard A"                                          # internal/features/rrdelete.feature:19
    Then the domain "$domain" doesn't have record "*.wildcard.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrdelete.feature:22

@rrpurge
Feature: rrpurge
  Scenario: I can purge a domain                                                    # internal/features/rrpurge.feature:2
    Given I have a domain "$domain"                                                 # internal/features/rrpurge.feature:3
    When I run "cli53 rrcreate $domain 'a A 127.0.0.1'"                             # internal/features/rrpurge.feature:4
    And I run "cli53 rrpurge --confirm $domain"                                     # internal/features/rrpurge.feature:5
    Then the domain "$domain" doesn't have record "a.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrpurge.feature:6

  Scenario: I can purge a domain with wildcard records                                       # internal/features/rrpurge.feature:8
    Given I have a domain "$domain"                                                          # internal/features/rrpurge.feature:9
    When I run "cli53 rrcreate $domain '*.wildcard A 127.0.0.1'"                             # internal/features/rrpurge.feature:10
    And I run "cli53 rrpurge --confirm $domain"                                              # internal/features/rrpurge.feature:11
    Then the domain "$domain" doesn't have record "*.wildcard.$domain. 3600 IN A 127.0.0.1"  # internal/features/rrpurge.feature:12

  Scenario: I can purge a domain with child NS record                                     # internal/features/rrpurge.feature:14
    Given I have a domain "$domain"                                                       # internal/features/rrpurge.feature:15
    When I run "cli53 rrcreate $domain 'a NS b.example.com.'"                             # internal/features/rrpurge.feature:16
    And I run "cli53 rrpurge --confirm $domain"                                           # internal/features/rrpurge.feature:17
    Then the domain "$domain" doesn't have record "a.$domain. 3600 IN NS b.example.com."  # internal/features/rrpurge.feature:20

@validation
Feature: parameter validation
  Scenario: identifier is required with failover                                # internal/features/validation.feature:2
    When I execute "cli53 rrcreate --failover PRIMARY $domain 'a A 127.0.0.1'"  # internal/features/validation.feature:3
    Then the exit code was 1                                                    # internal/features/validation.feature:4

  Scenario: identifier is required with weight                           # internal/features/validation.feature:6
    When I execute "cli53 rrcreate --weight 10 $domain 'a A 127.0.0.1'"  # internal/features/validation.feature:7
    Then the exit code was 1                                             # internal/features/validation.feature:8

  Scenario: identifier is required with region                                  # internal/features/validation.feature:10
    When I execute "cli53 rrcreate --region us-west-1 $domain 'a A 127.0.0.1'"  # internal/features/validation.feature:11
    Then the exit code was 1                                                    # internal/features/validation.feature:12

  Scenario: identifier alone is invalid                            # internal/features/validation.feature:14
    When I execute "cli53 rrcreate -i id $domain 'a A 127.0.0.1'"  # internal/features/validation.feature:15
    Then the exit code was 1                                       # internal/features/validation.feature:16

  Scenario: failover must be PRIMARY/SECONDARY                                     # internal/features/validation.feature:18
    When I execute "cli53 rrcreate -i id --failover JUNK $domain 'a A 127.0.0.1'"  # internal/features/validation.feature:19
    Then the exit code was 1                                                       # internal/features/validation.feature:20

  Scenario: failover and weight are mutually exclusive                                            # internal/features/validation.feature:22
    When I execute "cli53 rrcreate -i id --failover PRIMARY --weight 10 $domain 'a A 127.0.0.1'"  # internal/features/validation.feature:23
    Then the exit code was 1                                                                      # internal/features/validation.feature:24

  Scenario: passing --append and --replace at the same time makes no sense      # internal/features/validation.feature:26
    When I execute "cli53 rrcreate --append --replace $domain 'a A 127.0.0.2'"  # internal/features/validation.feature:27
    Then the exit code was 1                                                    # internal/features/validation.feature:28

  Scenario: create requires one argument    # internal/features/validation.feature:30
    When I execute "cli53 create a b"       # internal/features/validation.feature:31
    Then the exit code was 1                # internal/features/validation.feature:32

  Scenario: delete requires one argument    # internal/features/validation.feature:34
    When I execute "cli53 delete a b"       # internal/features/validation.feature:35
    Then the exit code was 1                # internal/features/validation.feature:36

  Scenario: import requires one argument    # internal/features/validation.feature:38
    When I execute "cli53 import a b"       # internal/features/validation.feature:39
    Then the exit code was 1                # internal/features/validation.feature:40

  Scenario: export requires one argument    # internal/features/validation.feature:42
    When I execute "cli53 export a b"       # internal/features/validation.feature:43
    Then the exit code was 1                # internal/features/validation.feature:44

  Scenario: rrcreate requires at least two arguments    # internal/features/validation.feature:46
    When I execute "cli53 rrcreate a"                   # internal/features/validation.feature:47
    Then the exit code was 1                            # internal/features/validation.feature:48

  Scenario: rrdelete requires three arguments    # internal/features/validation.feature:50
    When I execute "cli53 rrdelete a b c d"      # internal/features/validation.feature:51
    Then the exit code was 1                     # internal/features/validation.feature:52

  Scenario: rrpurge requires one argument    # internal/features/validation.feature:54
    When I execute "cli53 rrpurge a b"       # internal/features/validation.feature:55
    Then the exit code was 1                 # internal/features/validation.feature:56

  Scenario: list expects no arguments    # internal/features/validation.feature:58
    When I execute "cli53 list a"        # internal/features/validation.feature:59
    Then the exit code was 1             # internal/features/validation.feature:60

  Scenario: bad usage                  # internal/features/validation.feature:62
    When I execute "cli53 list --bad"  # internal/features/validation.feature:63
    Then the exit code was 1           # internal/features/validation.feature:66

Finished (323 passed, 2 failed, 0 skipped).

exit status 2
Makefile:26: recipe for target 'test-integration' failed
make: *** [test-integration] Error 1
```