### PR TITLE
Add --role-arn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ You can switch between different sets in the credentials file by passing
 
         cli53 list --profile my_profile
 
+You can also assume a specific role by passing `--role-arn` to any command.
+For example:
+
+        cli53 list --role-arn arn:aws:iam::123456789012:role/myRole
+
+You can combine role with profile.
+For example:
+
+        cli53 list --profile my_profile --role-arn arn:aws:iam::123456789012:role/myRole
+
 For more information, see: http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs
 
 Note: for Alpine on Docker, the pre-built binaries do not work, so either use Debian, or follow the instructions below for Building from source.

--- a/main.go
+++ b/main.go
@@ -28,6 +28,10 @@ func Main(args []string) int {
 			Usage: "profile to use from credentials file",
 		},
 		cli.StringFlag{
+			Name:  "role-arn",
+			Usage: "AWS role ARN to assume",
+		},
+		cli.StringFlag{
 			Name:  "endpoint-url",
 			Usage: "override Route53 endpoint (hostname or fully qualified URI)",
 		},

--- a/util.go
+++ b/util.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
@@ -69,6 +70,14 @@ func getService(c *cli.Context) (*route53.Route53, error) {
 	sess, err := session.NewSessionWithOptions(options)
 	if err != nil {
 		return nil, err
+	}
+	roleARN := c.String("role-arn")
+	if roleARN != "" {
+		roleCreds := stscreds.NewCredentials(sess, roleARN)
+		if err != nil {
+			return nil, err
+		}
+		config.Credentials = roleCreds
 	}
 	return route53.New(sess, config), nil
 }


### PR DESCRIPTION
# Purpose

When manage multiple accounts with centralized account in an automated system(Jenkins). Using profile requires multiple workarounds. Adding support for AWS Role assuming simplifies the system.

# Changes

- Add supports for `--role-arn` option for all commands.
- Add document for `--role-arn` option.

# Tests 

We didn't found any existing integration test related to the AWS credential part.
We'll be happy to add one, but we're not sure where to put these unit/integration tests to.

