### PR TITLE
Upgrade to go v1.13.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.12
+    - name: Set up Go 1.13.3
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13.3
 
     - name: Check out code
       uses: actions/checkout@v1
 
     - name: Download Go dependencies
-      env:
-        GOPROXY: "https://proxy.golang.org"
       run: go mod download
 
     - name: Get upx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13.3
+    - name: Set up Go 1.13.4
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.3
+        go-version: 1.13.4
 
     - name: Check out code
       uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.12
+    - name: Set up Go 13.3
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13.3
 
     - name: Check out code
       uses: actions/checkout@v1
@@ -22,7 +22,7 @@ jobs:
 
     - name: Run unit tests
       run: make test-unit
-      
+
     - name: Run test coverage
       run: |
         # gucumber only works from under GOPATH...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 13.3
+    - name: Set up Go 1.13.4
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.3
+        go-version: 1.13.4
 
     - name: Check out code
       uses: actions/checkout@v1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/barnybug/cli53
 
-go 1.12
+go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.13.34


### PR DESCRIPTION
Upgrade to go v1.13.3

Relates to https://github.com/Homebrew/homebrew-core/pull/45962
