### PR TITLE
Improve exit code tests debugging

### DIFF
--- a/internal/features/step_definitions.go
+++ b/internal/features/step_definitions.go
@@ -385,7 +385,7 @@ func init() {
 
 	Then(`^the exit code was (\d+)$`, func(code int) {
 		if code != retCode {
-			T.Errorf("Exit code expected: %d != actual: %d", code, retCode)
+			T.Errorf("Exit code expected: %d != actual: %d. Output: %s", code, retCode, runOutput)
 		}
 	})
 


### PR DESCRIPTION
In #320 a new set of validation tests were added, which passes locally but [fails in CI](https://github.com/barnybug/cli53/runs/5657877334?check_suite_focus=true):
```
@validate
Feature: validate a zone file syntax
  Scenario: correct zone file validation succeeds               # internal/features/validate.feature:2
    When I execute "cli53 validate --file tests/validate1.txt"  # internal/features/validate.feature:3
    Then the exit code was 0                                    # internal/features/validate.feature:4

Exit code expected: 0 != actual: 1
```

 Make troubleshooting of these issues slightly simpler by including command output in the error message.
